### PR TITLE
Fixed problem with line reader stream being closed

### DIFF
--- a/src/Seq.Client.Serilog/Client/Serilog/HttpLogShipper-net40.cs
+++ b/src/Seq.Client.Serilog/Client/Serilog/HttpLogShipper-net40.cs
@@ -251,10 +251,9 @@ namespace Seq.Client.Serilog
 
             current.Position = nextStart;
 
-            using (var reader = new StreamReader(current, Encoding.UTF8, false, 128))
-            {
-                nextLine = reader.ReadLine();
-            }
+            // Important not to dispose this StreamReader as the stream must remain open.
+            var reader = new StreamReader(current, Encoding.UTF8, false, 128);
+            nextLine = reader.ReadLine();
 
             if (nextLine == null)
                 return false;


### PR DESCRIPTION
TryReadLine method in HttpLogShipper no longer disposes "current" stream
