### PR TITLE
Http client fix

### DIFF
--- a/src/Seq.Client.Log4Net/Client/Log4Net/SeqAppender.cs
+++ b/src/Seq.Client.Log4Net/Client/Log4Net/SeqAppender.cs
@@ -44,10 +44,8 @@ namespace Seq.Client.Log4Net
             }
             set
             {
-                if (value.EndsWith("/"))
-                {
+                if (!value.EndsWith("/"))
                     value += "/";
-                }
 
                 _httpClient.BaseAddress = new Uri(value);
             }

--- a/src/Seq.Client.Log4Net/Client/Log4Net/SeqAppender.cs
+++ b/src/Seq.Client.Log4Net/Client/Log4Net/SeqAppender.cs
@@ -77,9 +77,11 @@ namespace Seq.Client.Log4Net
             if (!string.IsNullOrWhiteSpace(ApiKey))
                 content.Headers.Add(ApiKeyHeaderName, ApiKey);
 
-            var result = _httpClient.PostAsync(BulkUploadResource, content).Result;
-            if (!result.IsSuccessStatusCode)
-                ErrorHandler.Error(string.Format("Received failed result {0}: {1}", result.StatusCode, result.Content.ReadAsStringAsync().Result));
+            using (var result = _httpClient.PostAsync(BulkUploadResource, content).Result)
+            {
+                if (!result.IsSuccessStatusCode)
+                    ErrorHandler.Error(string.Format("Received failed result {0}: {1}", result.StatusCode, result.Content.ReadAsStringAsync().Result));
+            }
         }
     }
 }

--- a/src/Seq.Client.Log4Net/Client/Log4Net/SeqAppender.cs
+++ b/src/Seq.Client.Log4Net/Client/Log4Net/SeqAppender.cs
@@ -27,6 +27,8 @@ namespace Seq.Client.Log4Net
     /// </summary>
     public class SeqAppender : BufferingAppenderSkeleton
     {
+        readonly HttpClient _httpClient = new HttpClient();
+
         const string BulkUploadResource = "api/events/raw";
         const string ApiKeyHeaderName = "X-Seq-ApiKey";
 
@@ -34,7 +36,22 @@ namespace Seq.Client.Log4Net
         /// The address of the Seq server to write to. Specified in configuration
         /// like &lt;serverUrl value="http://my-seq:5341" /&gt;.
         /// </summary>
-        public string ServerUrl { get; set; }
+        public string ServerUrl
+        {
+            get
+            {
+                return _httpClient.BaseAddress?.OriginalString;
+            }
+            set
+            {
+                if (value.EndsWith("/"))
+                {
+                    value += "/";
+                }
+
+                _httpClient.BaseAddress = new Uri(value);
+            }
+        }
 
         /// <summary>
         /// A Seq <i>API key</i> that authenticates the client to the Seq server. Specified in configuration
@@ -60,16 +77,9 @@ namespace Seq.Client.Log4Net
             if (!string.IsNullOrWhiteSpace(ApiKey))
                 content.Headers.Add(ApiKeyHeaderName, ApiKey);
 
-            var baseUri = ServerUrl;
-            if (!baseUri.EndsWith("/"))
-                baseUri += "/";
-
-            using (var httpClient = new HttpClient { BaseAddress = new Uri(baseUri) })
-            {
-                var result = httpClient.PostAsync(BulkUploadResource, content).Result;
-                if (!result.IsSuccessStatusCode)
-                    ErrorHandler.Error(string.Format("Received failed result {0}: {1}", result.StatusCode, result.Content.ReadAsStringAsync().Result));
-            }
+            var result = _httpClient.PostAsync(BulkUploadResource, content).Result;
+            if (!result.IsSuccessStatusCode)
+                ErrorHandler.Error(string.Format("Received failed result {0}: {1}", result.StatusCode, result.Content.ReadAsStringAsync().Result));
         }
     }
 }

--- a/src/Seq.Client.Slab/Client/Slab/SeqSink.cs
+++ b/src/Seq.Client.Slab/Client/Slab/SeqSink.cs
@@ -136,17 +136,19 @@ namespace Seq.Client.Slab
                 if (!string.IsNullOrWhiteSpace(_apiKey))
                     content.Headers.Add(ApiKeyHeaderName, _apiKey);
 
-                var result = await _httpClient.PostAsync(BulkUploadResource, content);
-                if (!result.IsSuccessStatusCode)
+                using (var result = await _httpClient.PostAsync(BulkUploadResource, content))
                 {
-                    if (result.StatusCode == HttpStatusCode.BadRequest)
+                    if (!result.IsSuccessStatusCode)
                     {
-                        var error = string.Format("Received failed result from Seq {0}: {1}", result.StatusCode, result.Content.ReadAsStringAsync().Result);
-                        SemanticLoggingEventSource.Log.CustomSinkUnhandledFault(error);
-                        return batch.Events.Count;
-                    }
+                        if (result.StatusCode == HttpStatusCode.BadRequest)
+                        {
+                            var error = string.Format("Received failed result from Seq {0}: {1}", result.StatusCode, result.Content.ReadAsStringAsync().Result);
+                            SemanticLoggingEventSource.Log.CustomSinkUnhandledFault(error);
+                            return batch.Events.Count;
+                        }
 
-                    return 0;
+                        return 0;
+                    }
                 }
 
                 return batch.Events.Count;

--- a/src/Seq.Client.Slab/Client/Slab/SeqSink.cs
+++ b/src/Seq.Client.Slab/Client/Slab/SeqSink.cs
@@ -19,11 +19,11 @@ namespace Seq.Client.Slab
     /// </summary>
     public class SeqSink : IObserver<EventEntry>, IDisposable
     {
-        readonly string _serverUrl;
         readonly string _apiKey;
         readonly TimeSpan _onCompletedTimeout;
         readonly BufferedEventPublisher<EventEntry> _bufferedPublisher;
         readonly CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
+        readonly HttpClient _httpClient = new HttpClient();
 
         const string BulkUploadResource = "api/events/raw";
         const string ApiKeyHeaderName = "X-Seq-ApiKey";
@@ -56,7 +56,7 @@ namespace Seq.Client.Slab
             if (!baseUri.EndsWith("/"))
                 baseUri += "/";
 
-            _serverUrl = baseUri;
+            _httpClient.BaseAddress = new Uri(baseUri);
             _apiKey = apiKey;
             _onCompletedTimeout = onCompletedTimeout;
             _bufferedPublisher = BufferedEventPublisher<EventEntry>.CreateAndStart("Seq", PublishEventsAsync, bufferingInterval,
@@ -136,23 +136,20 @@ namespace Seq.Client.Slab
                 if (!string.IsNullOrWhiteSpace(_apiKey))
                     content.Headers.Add(ApiKeyHeaderName, _apiKey);
 
-                using (var httpClient = new HttpClient { BaseAddress = new Uri(_serverUrl) })
+                var result = await _httpClient.PostAsync(BulkUploadResource, content);
+                if (!result.IsSuccessStatusCode)
                 {
-                    var result = await httpClient.PostAsync(BulkUploadResource, content);
-                    if (!result.IsSuccessStatusCode)
+                    if (result.StatusCode == HttpStatusCode.BadRequest)
                     {
-                        if (result.StatusCode == HttpStatusCode.BadRequest)
-                        {
-                            var error = string.Format("Received failed result from Seq {0}: {1}", result.StatusCode, result.Content.ReadAsStringAsync().Result);
-                            SemanticLoggingEventSource.Log.CustomSinkUnhandledFault(error);
-                            return batch.Events.Count;
-                        }
-
-                        return 0;
+                        var error = string.Format("Received failed result from Seq {0}: {1}", result.StatusCode, result.Content.ReadAsStringAsync().Result);
+                        SemanticLoggingEventSource.Log.CustomSinkUnhandledFault(error);
+                        return batch.Events.Count;
                     }
 
-                    return batch.Events.Count;
+                    return 0;
                 }
+
+                return batch.Events.Count;
             }
             catch (OperationCanceledException)
             {


### PR DESCRIPTION
This patch will reduce costs of the HttpClient usage and resource cleanup.

The original of the problem was a network issue in the production system.
I see a hundreds of outgoing connections to the seri-log server port (5341) with the TIME_WAIT state in the system.
![image](https://cloud.githubusercontent.com/assets/1974640/16259626/e1f72b2c-3863-11e6-9932-d3eb3e686e0d.png)

With this patch i have solved this issue.
I'll be happy if it is can be useful to somebody else.