### PR TITLE
- Timeout property added to Log4Net SeqAppender

### DIFF
--- a/src/Seq.Client.Log4Net/Client/Log4Net/SeqAppender.cs
+++ b/src/Seq.Client.Log4Net/Client/Log4Net/SeqAppender.cs
@@ -62,6 +62,16 @@ namespace Seq.Client.Log4Net
         public string ApiKey { get; set; }
 
         /// <summary>
+        /// Gets or sets HttpClient timeout.
+        /// Specified in configuration like &lt;timeout value="00:00:01" /&gt; which coresponds to 1 second.
+        /// </summary>
+        public string Timeout
+        {
+            get { return _httpClient.Timeout.ToString(); }
+            set {  _httpClient.Timeout = TimeSpan.Parse(value); }
+        }
+
+        /// <summary>
         /// 
         /// </summary>
         protected List<AdoNetAppenderParameter> m_parameters = new List<AdoNetAppenderParameter>();


### PR DESCRIPTION
Default HttpClient timeout is set to 20 seconds, which is quite long. 

This pull request adds ability to set HttpClient.Timeout property via log4net configuration file:

```
<appender name="SeqAppender" type="...">
    <bufferSize value="1"/>
    <serverUrl value="https://seq.example.com/"/>
    <timeout value="00:00:01"/>
    <apiKey value="...."/>
</appender>
```